### PR TITLE
fix build error. specify the type of the argument so is not ambiguous anymore

### DIFF
--- a/ETTT/ConsoleUi.fs
+++ b/ETTT/ConsoleUi.fs
@@ -33,7 +33,7 @@ module ConsoleUi =
     /// Given that the user has not quit, attempt to parse
     /// the input text into a index and then find the move
     /// corresponding to that index
-    let processMoveIndex inputStr gameState availableMoves makeMove processInputAgain = 
+    let processMoveIndex (inputStr: string) gameState availableMoves makeMove processInputAgain =
         match Int32.TryParse inputStr with
         // TryParse will output a tuple (parsed?,int)
         | true,inputIndex ->


### PR DESCRIPTION
```
error FS0041: A unique overload for method 'TryParse' could not be determined based on type information prior to this program point. A type annotation may be needed. Candidates: Int32.TryParse(s: ReadOnlySpan<char>, result: byref<int>) : bool, Int32.TryParse(s: string, result: byref<int>) : bool
```

the `Int32.TryParse` allow argument of different types (it's an overloaded method).

- `string`
- `Span<char>`

The compiler cannot infer what `inputStr` should be. that's why the error.

Helping the compiler specifiying the type of `inputStr` make it easy for compiler to choose the right overload